### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/DirectoryBrowser.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/DirectoryBrowser.java
@@ -174,10 +174,7 @@ public class DirectoryBrowser {
                 if (file.isHidden() || !file.exists() || file.isDirectory() || !file.isFile()) {
                     return null;
                 }
-
-                RandomAccessFile raf;
-                try {
-                    raf = new RandomAccessFile(file, "r");
+                try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
                 } catch (Exception ignore) {
                     return null;
                 }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.